### PR TITLE
inline js -> listener based + several changes

### DIFF
--- a/extension/funcs.js
+++ b/extension/funcs.js
@@ -159,9 +159,9 @@ function checkChangeImp(){
 }
 
 // TODO: test what the hell it does
-function initiate() {
-	if (this.title!='done') {
-		this.title = 'done';
+function initiate(obj) {
+	if (obj.getAttribute('dat-title') != 'done') {
+		obj.setAttribute('data-title', 'done');
 		effects();
 	};
 }

--- a/extension/listeners.js
+++ b/extension/listeners.js
@@ -1,0 +1,35 @@
+// JS code responsible for attaching listeners to different
+// DOM elements
+
+var l = function(args) {
+	for(i = 0; i < args.length; i++) {
+		document.getElementById(args[i].id)[args[i].listener] = args[i].callback;
+	}
+}
+
+
+// for any further call backs attach it by passing as argument
+new l([
+		{
+			id: 'g4g',
+			listener: 'onmouseover',
+			callback: function() {
+				initiate(document.getElementById('g4g'));
+			}
+		},
+		{
+			id: 'donecheckbox',
+			listener: 'onchange',
+			callback: function() {checkChange();}
+		},
+		{
+			id: 'impcheckbox',
+			listener: 'onchange',
+			callback: function() {checkChangeImp();}
+		},
+		{
+			id: 'refresh',
+			listener: 'onclick',
+			callback: function() {refreshChange();}
+		}
+	]);

--- a/extension/main.js
+++ b/extension/main.js
@@ -83,33 +83,25 @@ function refreshChange() {
 
 refreshChange();
 
-// loading js files
-function reqListener () {
-	var script_eg = document.createElement('script');
-	script_eg.textContent = this.responseText;
-	(document.head||document.documentElement).appendChild(script_eg);
+var scriptInjection = function(scripts) {
+	this.toLoad = scripts.length;
+	this.loaded = 0;
+
+	var $this = this;
+	for(i = 0; i < this.toLoad; i++) {
+		var xhrObj = new XMLHttpRequest();
+		xhrObj.onload = function() {
+			var script_eg = document.createElement('script');
+			script_eg.textContent = this.responseText;
+			(document.head||document.documentElement).appendChild(script_eg);
+			$this.loaded++;
+		};
+		xhrObj.open("GET",chrome.extension.getURL(scripts[i]));
+		xhrObj.send();
+	}
 }
 
-var url = chrome.extension.getURL("funcs.js");
-var xhrObj = new XMLHttpRequest();
-xhrObj.onload = reqListener;
-xhrObj.open("GET",url);
-xhrObj.send();
-
-url = chrome.extension.getURL("jquery.js");
-var xhrObj = new XMLHttpRequest();
-xhrObj.onload = reqListener;
-xhrObj.open("GET",url);
-xhrObj.send();
-
-url = chrome.extension.getURL("jquery-ui.js");
-var xhrObj = new XMLHttpRequest();
-xhrObj.onload = reqListener;
-xhrObj.open("GET",url);
-xhrObj.send();
-
 // js files loaded
-
 if (typeof localStorage['done'] == 'undefined') {
 	var temp = [];
 	localStorage.setItem('done', JSON.stringify(temp));
@@ -126,7 +118,7 @@ if (typeof localStorage['color'] == 'undefined') {
 }
 // adding widget/tooltip
 
-var newDiv = "<div class='g4g draggable ui-widget-content' id='g4g' onmouseover='initiate()' title='Drag and Drop horizontally on screen'><input type='checkbox' onchange='checkChange()' id='donecheckbox'>Done |<input type='checkbox' onchange='checkChangeImp()' id='impcheckbox'>Important |   <button id='refresh' onclick = 'refreshChange()'>REFRESH</button></div>";
+var newDiv = "<div class='g4g draggable ui-widget-content' id='g4g' title='Drag and Drop horizontally on screen'><input type='checkbox' id='donecheckbox'>Done | <input type='checkbox' id='impcheckbox'>Important |   <button id='refresh'>REFRESH</button></div>";
 document.body.innerHTML += newDiv;
 
 // console.log('ahashashashjhjsadhjashjd');
@@ -155,4 +147,5 @@ if (impLinks.indexOf(document.URL)!=-1) {
 	};	
 }
 
+var sObj = new scriptInjection(['jquery.js', 'jquery-ui.js', 'funcs.js', 'listeners.js']);
 // widget added

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -20,5 +20,5 @@
    "permissions": [ "activeTab", "tabs", "storage" ],
    "short_name": "geekometer",
    "version": "1.2",
-   "web_accessible_resources": [ "funcs.js", "jquery.js", "jquery-ui.js" ]
+   "web_accessible_resources": [ "funcs.js", "jquery.js", "jquery-ui.js" , "listeners.js"]
 }


### PR DESCRIPTION
Tested - all olds things working
To make things work made several changes on the way.

#Problem 1: Since the `funcs.js` is injected, listeners could not be added till the script has loaded and functions, for ex `initiate()` is loaded. Also since the funcs.js is now loaded into page, the `variables` and `functions` doesn't comes to content scripts scope.
Solutions:
1. created a class `scriptInjection ` to load scripts into main HTML, `just to ease in the process`
2. Now since the functions are not in scope all event listeners need to be attached from the main scope of gfg, so created another script meant for loading listeners - `listeners.js`

#problem 2: the initiate is not loaded into memory even at the point the listeners is attached, {`probably due to async nature`} so attached it under a wrapper - `listeners.js line#16`, so `this` would still point to `window` object.
Solution: passed the reference object to `initate` and changed its definition to act accordingly